### PR TITLE
Added init gdb function to configspec

### DIFF
--- a/unicorefuzz/configspec.py
+++ b/unicorefuzz/configspec.py
@@ -38,14 +38,7 @@ def nop_func(*args, **kwargs) -> None:
     pass
 
 
-def init_avatar_target(ucf: Unicorefuzz, avatar: Avatar) -> Target:
-    """
-    Init the target used by the probe wrapper.
-    The probe_wrapper will set the breakpoint and forward regs and mem using this target.
-    :param ucf: Unicorefuzz instance, access config using ucf.config.
-    :param avatar: Initialized Avatar to add target to.
-    :return: An initialized target, added to Avatar.
-    """
+def init_avatar_target():
     from avatar2 import GDBTarget
 
     target = avatar.add_target(
@@ -170,8 +163,24 @@ UNICOREFUZZ_SPEC = [
         "init_avatar_target",
         Callable[[Unicorefuzz, Avatar], Target],
         lambda config: init_avatar_target,
-        init_avatar_target.__doc__,
+        """
+        Init the target used by the probe wrapper.
+        The probe_wrapper will set the breakpoint and forward regs and mem using this target.
+        :param ucf: Unicorefuzz instance, access config using ucf.config.
+        :param avatar: Initialized Avatar to add target to.
+        :return: An initialized target, added to Avatar.
+        """,
         "ucf, avatar",
+    ),
+    Optional(
+        "init_gdb_target",
+        Callable[[Target], None],
+        lambda config: nop_func,
+        """An initialization function called after attaching to the gdb target and before continuing its execution.
+        This function is useful to perform preliminary steps (e.g. disabling watchdogs, modifying memory etc.),
+        before running the target under gdb.
+        :param target: the avatar gdb target""",
+        "target",
     ),
 ]  # type: List[Union[Required, Optional]]
 

--- a/unicorefuzz/probe_wrapper.py
+++ b/unicorefuzz/probe_wrapper.py
@@ -141,6 +141,9 @@ class ProbeWrapper(Unicorefuzz):
         print("[*] Initializing Avatar2")
         target = self.config.init_avatar_target(self, avatar)  # type: Target
 
+        print("[*] Initializing Avatar2 gdb target")
+        self.config.init_gdb_target(target)
+
         target.set_breakpoint("*{}".format(breakaddress))
         print("[+] Breakpoint set at {}".format(breakaddress))
         print("[*] Waiting for bp hit...")


### PR DESCRIPTION
This additional initialization function allows to make basic preliminary steps before running the target under the debugger.

For example, it is useful to disable watchdogs or patch specific region of memories before running.